### PR TITLE
Update README to make instructions a little clearer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,22 +7,33 @@ to be usable in Angular projects.
     bower install ng-iframe-resizer --save
 
 ## Instructions
-How to use the ng-iframe-resizer directive in your Angular application.
+How to use the ng-iframe-resizer directive in your Angular application:
 
+- Include the following two JS files in your project:
+
+```html
+<script src="[your bower_components folder]/iframe-resizer/js/iframeResizer.js" type="text/javascript"></script>
+<script src="[your bower_components folder]/ng-iframe-resizer/dist/iframe-resizer.js" type="text/javascript"></script>
+```
+
+- Tell Angular to include the module as per usual:
 ```js
-// Include it in Angular as per
 angular.module("app", ["ngIframeResizer"])
 ```
 
+- You need to place the original [iframeResizer.contentWindow.min.js](https://raw.github.com/davidjbradshaw/iframe-resizer/master/js/iframeResizer.contentWindow.min.js)
+in the source page within your iFrame. This file is designed to be a guest on
+someone else's system, so has no dependencies and won't do anything until it's
+activated by a message from the iFrame's parent page.
 ```html
-<!-- After that it's ready to use -->
+<script src="iframeResizer.contentWindow.min.js" type="text/javascript"></script>
+```
+
+- After that, it's ready to use as an Angular directive (attribute):
+```html
 <iframe src="http://anotherdomain.com/iframe.html" scrolling="no" ng-iframe-resizer></iframe>
 ```
 
-Also, you need to place the original [iframeResizer.contentWindow.min.js](https://raw.github.com/davidjbradshaw/iframe-resizer/master/js/iframeResizer.contentWindow.min.js)
-in the page contained within your iFrame. This file is designed to be a guest on
-someone else's system, so has no dependencies and won't do anything until it's
-activated by a message from the containing page.
 
 ## License
 Copyright &copy; 2015 [Joao Dias](https://github.com/alfaproject).

--- a/bower.json
+++ b/bower.json
@@ -37,10 +37,10 @@
     "gulp*"
   ],
   "dependencies": {
-    "angular": "~1.3.0",
+    "angular": ">=1.3.0",
     "iframe-resizer": "~2.8.0"
   },
   "devDependencies": {
-    "angular-mocks": "~1.3.0"
+    "angular-mocks": ">=1.3.0"
   }
 }

--- a/bower.json
+++ b/bower.json
@@ -37,10 +37,10 @@
     "gulp*"
   ],
   "dependencies": {
-    "angular": ">=1.3.0",
+    "angular": "^1.3.0",
     "iframe-resizer": "~2.8.0"
   },
   "devDependencies": {
-    "angular-mocks": ">=1.3.0"
+    "angular-mocks": "^1.3.0"
   }
 }


### PR DESCRIPTION
I ran into the issue where it wasn't explicitly mentioned, so I didn't do it - but the original iFrameResizer script needs to be pulled in as well. This makes perfect sense, and most folks probably don't miss it - but figured it'd be helpful.

I also re-organized a few of the steps - pulling in the iFrame contentWindow script in the iframe source page is an important step, but in the README since it was at the end it was kind of an afterthought.
